### PR TITLE
Todo single page

### DIFF
--- a/src/components/todo/Todo.tsx
+++ b/src/components/todo/Todo.tsx
@@ -1,6 +1,10 @@
 import type {Todo} from "./types.ts";
 import { statusColor} from "./status.ts";
 import {TodoActions} from "./TodoActions.tsx";
+import {Link} from "react-router-dom";
+import {routerConfig} from "../../pages/routerConfig.ts";
+import axios from "axios";
+import {Trash} from "lucide-react";
 
 type TodoProps = {
     todo: Todo
@@ -9,14 +13,35 @@ type TodoProps = {
 
 
 export function Todo({todo, getTodos}: TodoProps) {
+
+    const handleDelete = async (id: string) => {
+        try {
+            const response = await axios.delete(`${routerConfig.API.TODOS}/${id}`);
+            if (response.status === 200) {
+                getTodos()
+            }
+        }
+        catch (error) {
+            console.log(error);
+        }
+    }
+
+
     return (
         <div className="bg-gray-100 border border-gray-300 rounded-lg shadow p-4 flex flex-col gap-2 mb-4">
-            <div className="flex justify-end">
+            <div className="flex justify-between">
+                <div className="flex gap-2">
+                    <button className="text-black" onClick={()=>handleDelete(todo.id)}>
+                        <Trash className="w-4 h-4" />
+                    </button>
+
+                </div>
                  <span className={`px-2 py-1 rounded-full text-xs font-bold self-start ${statusColor[todo.status]}`}>
                     {todo.status}
                  </span>
             </div>
-            <div className="text-black font-semibold text-lg">{todo.description}</div>
+            <Link to={`${routerConfig.URL.TODO}/${todo.id}`} >
+            <div className="text-black font-semibold text-lg">{todo.description}</div></Link>
 
             <TodoActions todo={todo} getTodos={getTodos}/>
         </div>

--- a/src/components/todo/TodoStatusButton.tsx
+++ b/src/components/todo/TodoStatusButton.tsx
@@ -1,6 +1,7 @@
 import {MoveRight, MoveLeft} from "lucide-react";
 import type {Status, Todo} from "./types.ts";
 import axios from "axios";
+import {status as statusConst} from "./status.ts";
 
 type TodoStatusButtonProps = {
     statusColors: string;
@@ -22,15 +23,15 @@ export function TodoStatusButton({todo , status, statusColors, getTodos}: TodoSt
             console.log(error);
         }
     }
-console.log(status);
+
     return (
         <button
             onClick={() => handleUpdateTodoStatus()}
             className={`px-2 py-1 font-bold self-start  ${statusColors} rounded text-xs flex items-center gap-1 transition`}>
-            {status === "IN_PROGRESS" && todo.status === "OPEN" && <MoveRight/> }
-            {status === "OPEN" && todo.status === "IN_PROGRESS" && <MoveLeft/> }
-            {status === "IN_PROGRESS" && todo.status === "DONE" && <MoveLeft/> }
-            {status === "DONE" && <MoveRight/> }
+            {status === statusConst.IN_PROGRESS && todo.status === statusConst.OPEN && <MoveRight/> }
+            {status === statusConst.OPEN && todo.status === statusConst.IN_PROGRESS && <MoveLeft/> }
+            {status === statusConst.IN_PROGRESS && todo.status === statusConst.DONE && <MoveLeft/> }
+            {status === statusConst.DONE && <MoveRight/> }
         </button>)
 }
 

--- a/src/pages/Router.tsx
+++ b/src/pages/Router.tsx
@@ -1,12 +1,13 @@
 import {routerConfig} from "./routerConfig.ts";
 import {Route, Routes} from "react-router-dom";
+import {TodosPage} from "./TodosPage.tsx";
 import {TodoPage} from "./TodoPage.tsx";
 
 export function Router() {
     return (
         <Routes>
-            <Route path={routerConfig.URL.HOME} element={<TodoPage />} />
-
+            <Route path={routerConfig.URL.HOME} element={<TodosPage />} />
+            <Route path={`${routerConfig.URL.TODO}/:id`} element={<TodoPage />} />
         </Routes>
     )
 }

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -56,7 +56,7 @@ export function TodoPage() {
                 className="w-[300px] flex gap-2  flex-col "
             >
                 <div>
-                    <label className="block text-left mb-2" htmlFor="text">Todo description</label>
+                    <label className="block text-left mb-2" htmlFor="text">Edit description</label>
                     <input
                         type="text"
                         name="text"
@@ -66,7 +66,7 @@ export function TodoPage() {
                     />
                 </div>
                 <div>
-                    <label className="block text-left mb-2" htmlFor="status">Todo status</label>
+                    <label className="block text-left mb-2" htmlFor="status">Edit status</label>
 
                     <select
                         name="status"

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -3,6 +3,7 @@ import {type FormEvent, useEffect, useState} from "react";
 import {routerConfig} from "./routerConfig.ts";
 import axios from "axios";
 import {type Todo} from "../components/todo/types.ts"
+import {status} from "../components/todo/status.ts";
 
 export function TodoPage() {
     const navigate = useNavigate()
@@ -73,9 +74,9 @@ export function TodoPage() {
                         onChange={e => setEditStatus(e.target.value)}
                         className="border rounded px-2 py-1 w-full"
                     >
-                        <option value="OPEN">OPEN</option>
-                        <option value="IN_PROGRESS">IN_PROGRESS</option>
-                        <option value="DONE">DONE</option>
+                        <option value={status.OPEN}>{status.OPEN}</option>
+                        <option value={status.IN_PROGRESS}>{status.IN_PROGRESS}</option>
+                        <option value={status.DONE}>{status.DONE}</option>
                     </select>
                 </div>
                 <button

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -47,7 +47,7 @@ export function TodoPage() {
     useEffect(() => {
             getTodo()
         },
-        [id])
+        [])
 
     return (
         <div className="w-full flex flex-col items-center h-screen justify-center">

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,0 +1,90 @@
+import {useNavigate, useParams} from "react-router-dom";
+import {type FormEvent, useEffect, useState} from "react";
+import {routerConfig} from "./routerConfig.ts";
+import axios from "axios";
+import {type Todo} from "../components/todo/types.ts"
+
+export function TodoPage() {
+    const navigate = useNavigate()
+    const [todo, setTodo] = useState<Todo>()
+    const [editText, setEditText] = useState("");
+    const [editStatus, setEditStatus] = useState("OPEN");
+
+    const {id} = useParams()
+
+    const getTodo = async () => {
+        try {
+            const response = await axios.get(`${routerConfig.API.TODOS}/${id}`)
+            if (response.status === 200) {
+                setTodo(response.data)
+                setEditStatus(response.data.status)
+                setEditText(response.data.description)
+            }
+        } catch (e) {
+            console.error(e)
+        }
+    }
+
+    const handleSubmit = async (e: FormEvent): Promise<void> => {
+        e.preventDefault();
+        try {
+            if (todo) {
+                const response = await axios.put(`${routerConfig.API.TODOS}/${todo.id}/update`, {
+                    ...todo,
+                    description: editText,
+                    status: editStatus
+                });
+                if (response.status === 200) {
+                    navigate(routerConfig.URL.HOME);
+                }
+            }
+        } catch (err) {
+            console.error(err);
+        }
+    }
+
+    useEffect(() => {
+            getTodo()
+        },
+        [id])
+
+    return (
+        <div className="w-full flex flex-col items-center h-screen justify-center">
+            <form
+                onSubmit={handleSubmit}
+                className="w-[300px] flex gap-2  flex-col "
+            >
+                <div>
+                    <label className="block text-left mb-2" htmlFor="text">Todo description</label>
+                    <input
+                        type="text"
+                        name="text"
+                        value={editText}
+                        onChange={e => setEditText(e.target.value)}
+                        className="border rounded px-2 py-1 w-full"
+                    />
+                </div>
+                <div>
+                    <label className="block text-left mb-2" htmlFor="status">Todo status</label>
+
+                    <select
+                        name="status"
+                        value={editStatus}
+                        onChange={e => setEditStatus(e.target.value)}
+                        className="border rounded px-2 py-1 w-full"
+                    >
+                        <option value="OPEN">OPEN</option>
+                        <option value="IN_PROGRESS">IN_PROGRESS</option>
+                        <option value="DONE">DONE</option>
+                    </select>
+                </div>
+                <button
+                    type="submit"
+                    className="border px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 transition"
+                >
+                    Save
+                </button>
+            </form>
+        </div>
+    )
+}

--- a/src/pages/TodosPage.tsx
+++ b/src/pages/TodosPage.tsx
@@ -22,8 +22,6 @@ export function TodosPage() {
         getTodos()
     }, []);
 
-    console.log(todos);
-
     return (
         <>
             <div className=" flex justify-between items-end mb-12">

--- a/src/pages/TodosPage.tsx
+++ b/src/pages/TodosPage.tsx
@@ -5,7 +5,7 @@ import type {Todo as TodoType, TodoGetResponse} from "../components/todo/types.t
 import {TodoStatusColumn} from "../components/todo/TodoStatusColumn.tsx";
 import {TodoCreate} from "../components/todo/TodoCreate.tsx";
 
-export function TodoPage() {
+export function TodosPage() {
     const [todos, setTodos] = useState<TodoType[]>([])
 
 

--- a/src/pages/routerConfig.ts
+++ b/src/pages/routerConfig.ts
@@ -5,6 +5,7 @@ type RouterConfig = {
 
 type URL = {
     HOME: string,
+    TODO: string,
 }
 
 type API = {
@@ -14,6 +15,7 @@ type API = {
 export const routerConfig:RouterConfig = {
     URL:{
         HOME:"/",
+        TODO:"/todo"
     },
     API:{
         TODOS:"/api/todo",


### PR DESCRIPTION
This pull request refactors the todo application to introduce individual todo detail and edit pages, improves code organization, and enhances UI interactions. The main changes include splitting the todos list and todo detail views, implementing navigation between them, and adding delete functionality. Additionally, status handling is made more robust and code is cleaned up for better maintainability.

**Routing and Page Structure Updates:**
* Added a new `TodosPage` for listing all todos and refactored routing so the home page shows the todos list, with a new route for viewing/editing a single todo (`/todo/:id`). (`src/pages/Router.tsx`, `src/pages/TodosPage.tsx`, `src/pages/TodoPage.tsx`, `src/pages/routerConfig.ts`).

**Todo Detail and Edit Functionality:**
* Implemented a dedicated todo detail/edit page (`TodoPage`) with form-based editing for description and status, including API integration for updating todos. (`src/pages/TodoPage.tsx`)

**Todos List Improvements:**
* Updated the todos list to link each todo to its detail/edit page and added a delete button for removing todos directly from the list. (`src/components/todo/Todo.tsx`) 

**Status Handling Consistency:**
* Refactored status comparisons in `TodoStatusButton` to use constants for better reliability and maintainability. (`src/components/todo/TodoStatusButton.tsx`)

Let me know if you want to walk through any specific part of these changes or need help understanding how the new routing and page structure works!